### PR TITLE
Bug/stub component context callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "mocha tests/unit/ --recursive --reporter spec",
-    "cover": "istanbul cover --dir artifacts -- ./node_modules/mocha/bin/_mocha tests/unit/ --recursive --reporter spec",
+    "cover": "istanbul cover --dir artifacts -- _mocha tests/unit/ --recursive --reporter spec",
     "lint": "jshint"
   },
   "dependencies": {

--- a/tests/unit/utils/MockComponentContext.js
+++ b/tests/unit/utils/MockComponentContext.js
@@ -1,0 +1,100 @@
+/* jshint newcap:false */
+/* global describe, it, before, after */
+
+'use strict';
+
+var ROOT_DIR = require('path').resolve(__dirname + '/../../..');
+
+var expect = require('chai').expect;
+var mockery = require('mockery');
+
+describe('MockComponentContext', function () {
+    var MockComponentContext;
+
+    function dispatchr () {}
+    dispatchr.prototype.getStore = function () {};
+
+    before(function () {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+
+        mockery.registerMock('dispatchr', function () {
+            return dispatchr;
+        });
+
+        MockComponentContext = require(ROOT_DIR + '/utils/MockComponentContext');
+    });
+
+    it('should be a function', function () {
+        expect(MockComponentContext).to.be.a('function');
+    });
+
+    describe('ComponentContext', function () {
+        var ComponentContext;
+
+        before(function() {
+            ComponentContext = MockComponentContext();
+        });
+
+        it('should be a constructor', function () {
+            expect(new ComponentContext()).to.be.an.instanceof(ComponentContext);
+        });
+
+        it('should have a Dispatcher property that is dispatchr', function() {
+            expect(ComponentContext).to.have.property('Dispatcher', dispatchr);
+        });
+
+        describe('instance', function () {
+            var context;
+
+            before(function () {
+                context = new ComponentContext();
+            });
+
+            it('should have the following properties: dispatcher, executeActionCalls', function () {
+                expect(context).to.have.property('dispatcher').that.is.an.instanceof(dispatchr);
+                expect(context).to.have.property('executeActionCalls').that.is.an('array').and.empty();
+            });
+
+            describe('#getStore', function () {
+                it('should delegate to the dispatcher getStore method', function () {
+                    expect(context).to.have.property('getStore', dispatchr.getStore);
+                });
+            });
+
+            describe('#executeAction', function () {
+                it('should provide an executeAction method', function () {
+                    expect(context).to.respondTo('executeAction');
+                });
+
+                it('should execute the action', function () {
+                    var mockPayload = {
+                        foo: 'bar',
+                        baz: 'fubar'
+                    };
+
+                    function mockAction (ctx, payload, done) {
+                        expect(ctx).to.equal(context);
+                        expect(payload).to.equal(mockPayload);
+                        done();
+                    }
+
+                    context.executeAction(mockAction, mockPayload);
+
+                    expect(context.executeActionCalls).to.have.length(1);
+
+                    var call = context.executeActionCalls[0];
+                    expect(call).to.have.property('action', mockAction);
+                    expect(call).to.have.property('payload', mockPayload);
+                });
+            });
+        });
+    });
+
+    after(function() {
+        mockery.deregisterAll();
+        mockery.disable();
+    });
+});

--- a/utils/MockComponentContext.js
+++ b/utils/MockComponentContext.js
@@ -14,7 +14,6 @@ module.exports = function createMockComponentContextClass() {
     function MockComponentContext () {
         this.dispatcher = new Dispatcher();
         this.executeActionCalls = [];
-        this.dispatchCalls = [];
     }
 
     MockComponentContext.prototype.getStore = function (name) {

--- a/utils/MockComponentContext.js
+++ b/utils/MockComponentContext.js
@@ -6,28 +6,30 @@
 
 var dispatchr = require('dispatchr');
 
+function noop () {}
+
 module.exports = function createMockComponentContextClass() {
     var Dispatcher = dispatchr();
 
-    function MockActionContext () {
+    function MockComponentContext () {
         this.dispatcher = new Dispatcher();
         this.executeActionCalls = [];
         this.dispatchCalls = [];
     }
 
-    MockActionContext.prototype.getStore = function (name) {
+    MockComponentContext.prototype.getStore = function (name) {
         return this.dispatcher.getStore(name);
     };
 
-    MockActionContext.prototype.executeAction = function (action, payload, callback) {
+    MockComponentContext.prototype.executeAction = function (action, payload) {
         this.executeActionCalls.push({
             action: action,
             payload: payload
         });
-        action(this, payload, callback);
+        action(this, payload, noop);
     };
 
-    MockActionContext.Dispatcher = Dispatcher;
+    MockComponentContext.Dispatcher = Dispatcher;
 
-    return MockActionContext;
+    return MockComponentContext;
 };


### PR DESCRIPTION
@mridgway @redonkulus 

pass noop function as callback to executeAction in mockComponentContext
rename MockActionContext -> MockComponentContext
change npm run dev to use _mocha as opposed to ./node_modules/mocha/.bin/_mocha

add unit tests for utils/MockComponentContext
remove dispatchCalls array from componentContext since it can never be populated